### PR TITLE
Updated to use newest version of elasticsearch

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,8 +7,8 @@ sudo apt-get install -y -qq redis-server
 sudo apt-get install -y -qq openjdk-7-jre-headless
 
 echo "Installing Elasticsearch"
-wget -q https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.2.0.deb
-sudo dpkg -i elasticsearch-1.2.0.deb > /dev/null
+wget -q https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.2.1.deb
+sudo dpkg -i elasticsearch-1.2.1.deb > /dev/null
 sudo service elasticsearch start
 
 sudo apt-get install -y libxml2-dev libxslt1-dev python-dev python-setuptools python-virtualenv git > /dev/null


### PR DESCRIPTION
Updated wget elasticsearch-1.2.0 (which now gives http 404) to elasticsearch-1.2.1
