### PR TITLE
Cryptographic lib introduced for #55 require libssl-dev and libffi-dev t...

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -53,9 +53,9 @@ Installation
    $ wget https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.2.0.deb
    $ sudo dpkg -i elasticsearch-1.2.0.deb
 
-4. Install liblxml, libxslt and python-dev::
+4. Install liblxml, libxslt, libssl, libffi and python-dev::
 
-   $ sudo apt-get install libxml2-dev libxslt1-dev python-dev
+   $ sudo apt-get install libxml2-dev libxslt1-dev libssl-dev libffi-dev python-dev
 
 5. Install pip and virtualenv::
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -11,7 +11,7 @@ wget -q https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticse
 sudo dpkg -i elasticsearch-1.2.1.deb > /dev/null
 sudo service elasticsearch start
 
-sudo apt-get install -y libxml2-dev libxslt1-dev python-dev python-setuptools python-virtualenv git > /dev/null
+sudo apt-get install -y libxml2-dev libxslt1-dev libssl-dev libffi-dev python-dev python-setuptools python-virtualenv git > /dev/null
 sudo easy_install -q pip
 virtualenv -q ocd
 


### PR DESCRIPTION
...o be installed in order to properly build Vagrant box. Updated manual installation docs too.
