### PR TITLE
Deployment strategy

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -110,6 +110,7 @@ def push_sources():
 
 @task
 def build_documentation():
+    ensure_virtualenv()
     with virtualenv(env.virtualenv):
         with cd(env.code_dir):
             run('sphinx-build docs %s' % env.docs_built_dir)

--- a/fabfile.py
+++ b/fabfile.py
@@ -110,8 +110,9 @@ def push_sources():
 
 @task
 def build_documentation():
-    with cd(env.code_dir):
-        run('sphinx-build docs %s' % env.docs_built_dir)
+    with virtualenv(env.virtualenv):
+        with cd(env.code_dir):
+            run('sphinx-build docs %s' % env.docs_built_dir)
 
 
 @task

--- a/fabfile.py
+++ b/fabfile.py
@@ -63,11 +63,15 @@ def install_dependencies():
     with virtualenv(env.virtualenv):
         with cd(env.code_dir):
             run_venv("pip install -r requirements.txt")
-            put("ocd_backend/local_settings_%s.py" % (
-                env.stage), os.path.join(
+            backend_local_file = "ocd_backend/local_settings_%s.py" % (
+                env.stage)
+            frontend_local_file = "ocd_frontend/local_settings_%s.py" % (
+                env.stage)
+            if os.path.exists(backend_local_file):
+                put(backend_local_file, os.path.join(
                     env.project_dir, 'ocd_backend/local_settings.py'))
-            put("ocd_frontend/local_settings_%s.py" % (
-                env.stage), os.path.join(
+            if os.path.exists(frontend_local_file):
+                put(frontend_local_file, os.path.join(
                     env.project_dir, 'ocd_frontend/local_settings.py'))
 
 

--- a/fabfile.py
+++ b/fabfile.py
@@ -113,7 +113,7 @@ def build_documentation():
     ensure_virtualenv()
     with virtualenv(env.virtualenv):
         with cd(env.code_dir):
-            run('sphinx-build docs %s' % env.docs_built_dir)
+            run_venv('sphinx-build docs %s' % env.docs_built_dir)
 
 
 @task

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,194 @@
+"""
+Starter fabfile for deploying the open cultuurdata api.
+
+Change all the things marked CHANGEME. Other things can be left at their
+defaults if you are happy with the default layout.
+"""
+
+import os
+import posixpath
+from pprint import pprint
+
+from fabric.api import run, local, env, settings, cd, task, put, execute
+from fabric.contrib.files import exists
+from fabric.operations import _prefix_commands, _prefix_env_vars, require
+#from fabric.decorators import runs_once
+#from fabric.context_managers import cd, lcd, settings, hide
+
+# CHANGEME
+STAGES = {
+    'test': {
+        #  'hosts': ['breyten@api.opencultuurdata.nl'],
+        'hosts': ['api.opencultuurdata.nl'],
+        'code_dir': '/home/breyten/open-cultuur-data-test',
+        'code_branch': 'dev',
+        'project_dir': '/home/breyten/open-cultuur-data-test',
+        'virtualenv': '/home/breyten/open-cultuur-data-test/.virtualenv',
+        'code_repo': 'git@github.com:openstate/open-cultuur-data.git',
+    },
+    'production': {
+        'hosts': ['breyten@api.opencultuurdata.nl'],
+        'code_dir': '/home/breyten/open-cultuur-data',
+        'code_branch': 'master',
+        'project_dir': '/home/breyten/open-cultuur-data',
+        'virtualenv': '/home/breyten/open-cultuur-data/.virtualenv',
+        'code_repo': 'git@github.com:openstate/open-cultuur-data.git',
+    }
+}
+
+# Python version
+PYTHON_BIN = "python2.7"
+PYTHON_PREFIX = ""  # e.g. /usr/local  Use "" for automatic
+PYTHON_FULL_PATH = "%s/bin/%s" % (
+    PYTHON_PREFIX, PYTHON_BIN) if PYTHON_PREFIX else PYTHON_BIN
+
+
+def virtualenv(venv_dir):
+    """
+    Context manager that establishes a virtualenv to use.
+    """
+    return settings(venv=venv_dir)
+
+
+def run_venv(command, **kwargs):
+    """
+    Runs a command in a virtualenv (which has been specified using
+    the virtualenv context manager
+    """
+    run("source %s/bin/activate" % env.virtualenv + " && " + command, **kwargs)
+
+
+def install_dependencies():
+    ensure_virtualenv()
+    with virtualenv(env.virtualenv):
+        with cd(env.code_dir):
+            run_venv("pip install -r requirements.txt")
+            put("ocd_backend/local_settings_%s.py" % (
+                env.stage, os.path.join(
+                    env.project_dir, 'ocd_backend/local_settings.py')))
+            put("ocd_frontend/local_settings_%s.py" % (
+                env.stage, os.path.join(
+                    env.project_dir, 'ocd_frontend/local_settings.py')))
+
+
+def ensure_virtualenv():
+    if exists(env.virtualenv):
+        return
+
+    with cd(env.code_dir):
+        run("virtualenv --no-site-packages --python=%s %s" %
+            (PYTHON_BIN, env.virtualenv))
+        run("echo %s > %s/lib/%s/site-packages/projectsource.pth" %
+            (env.project_dir, env.virtualenv, PYTHON_BIN))
+
+
+def ensure_src_dir():
+    if not exists(env.code_dir):
+        run("mkdir -p %s" % env.code_dir)
+    with cd(env.code_dir):
+        if not exists(posixpath.join(env.code_dir, '.git')):
+            run('git clone --branch=%s %s .' % (
+                env.code_branch, env.code_repo,))
+
+
+def push_sources():
+    """
+    Push source code to server
+    """
+    ensure_src_dir()
+    local('git checkout %s && git push origin %s' % (
+        env.code_branch, env.code_branch,))
+    with cd(env.code_dir):
+        run('git pull origin %s' % env.code_branch)
+
+
+@task
+def run_tests():
+    """ Runs the Django test suite as is.  """
+    local("./run_tests.sh")
+
+
+@task
+def version():
+    """ Show last commit to the deployed repo. """
+    with cd(env.code_dir):
+        run('git log -1')
+
+
+@task
+def uname():
+    """ Prints information about the host. """
+    run("uname -a")
+
+
+@task
+def webserver_restart():
+    """
+    Restarts the webserver that is running the Django instance
+    """
+    pass
+
+
+def restart():
+    """ Restart the wsgi process """
+    with cd(env.code_dir):
+        run("touch %s/uwsgi.txt" % env.code_dir)
+
+
+@task
+def first_deployment_mode():
+    """
+    Use before first deployment to switch on fake south migrations.
+    """
+    env.initial_deploy = True
+
+
+@task
+def sshagent_run(cmd):
+    """
+    Helper function.
+    Runs a command with SSH agent forwarding enabled.
+
+    Note:: Fabric (and paramiko) can't forward your SSH agent.
+    This helper uses your system's ssh to do so.
+    """
+    # Handle context manager modifications
+    wrapped_cmd = _prefix_commands(_prefix_env_vars(cmd), 'remote')
+    try:
+        host, port = env.host_string.split(':')
+        return local(
+            "ssh -p %s -A %s@%s '%s'" % (port, env.user, host, wrapped_cmd)
+        )
+    except ValueError:
+        return local(
+            "ssh -A %s@%s '%s'" % (env.user, env.host_string, wrapped_cmd)
+        )
+
+
+def stage_set(stage_name='test'):
+    env.stage = stage_name
+    for option, value in STAGES[env.stage].items():
+        setattr(env, option, value)
+
+
+@task
+def production():
+    stage_set('production')
+
+
+@task
+def test():
+    stage_set('test')
+
+
+@task
+def deploy():
+    """
+    Deploy the project.
+    """
+
+    require('stage', provided_by=(test, production,))
+
+    push_sources()
+    install_dependencies()
+    webserver_restart()

--- a/fabfile.py
+++ b/fabfile.py
@@ -25,6 +25,7 @@ STAGES = {
         'project_dir': '/home/breyten/open-cultuur-data-test',
         'virtualenv': '/home/breyten/open-cultuur-data-test/.virtualenv',
         'code_repo': 'git@github.com:openstate/open-cultuur-data.git',
+        'docs_built_dir': '/home/breyten/open-cultuur-data-test/docs-built'
     },
     'production': {
         'hosts': ['breyten@api.opencultuurdata.nl'],
@@ -33,6 +34,7 @@ STAGES = {
         'project_dir': '/home/breyten/open-cultuur-data',
         'virtualenv': '/home/breyten/open-cultuur-data/.virtualenv',
         'code_repo': 'git@github.com:openstate/open-cultuur-data.git',
+        'docs_built_dir': '/home/breyten/open-cultuur-data-test/docs-built'
     }
 }
 
@@ -104,6 +106,12 @@ def push_sources():
         env.code_branch, env.code_branch,))
     with cd(env.code_dir):
         run('git pull origin %s' % env.code_branch)
+
+
+@task
+def build_documentation():
+    with cd(env.code_dir):
+        run('sphinx-build docs %s' % env.docs_built_dir)
 
 
 @task
@@ -195,4 +203,5 @@ def deploy():
 
     push_sources()
     install_dependencies()
+    build_documentation()
     webserver_restart()

--- a/fabfile.py
+++ b/fabfile.py
@@ -64,11 +64,11 @@ def install_dependencies():
         with cd(env.code_dir):
             run_venv("pip install -r requirements.txt")
             put("ocd_backend/local_settings_%s.py" % (
-                env.stage, os.path.join(
-                    env.project_dir, 'ocd_backend/local_settings.py')))
+                env.stage), os.path.join(
+                    env.project_dir, 'ocd_backend/local_settings.py'))
             put("ocd_frontend/local_settings_%s.py" % (
-                env.stage, os.path.join(
-                    env.project_dir, 'ocd_frontend/local_settings.py')))
+                env.stage), os.path.join(
+                    env.project_dir, 'ocd_frontend/local_settings.py'))
 
 
 def ensure_virtualenv():

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ Sphinx==1.2.2
 sphinxcontrib-httpdomain==1.2.1
 sphinx-rtd-theme==0.1.6
 BeautifulSoup==3.2.1
+Fabric==1.10.1


### PR DESCRIPTION
Add a fabfile for running deployments. This does not yet restart the webserver or any such fancy things. But it does build the documentation with sphinx when running a deployment

I guess the question is whether we want to autmatically restart the webserver -- This would require running the server under wsgi though, which is currently not the case. (Alternatively we could do that at a later stage of course.)

Any other comments? Should I add a task for easy remote crawling?