### PR TITLE
No chords in pipeline

### DIFF
--- a/docs/user/datasets.rst
+++ b/docs/user/datasets.rst
@@ -364,7 +364,7 @@ Visserijmuseum Zoutkamp index
 TextielMuseum
 -------------
 
-This dataset contains images  from the `TextielMuseum <http://www.textielmuseum/>`_.
+This dataset contains images  from the `TextielMuseum <http://www.textielmuseum.nl/>`_.
 Content is harvested by using the `Adlib API <http://api.adlibsoft.com/site/>`_.
 
 Combined index

--- a/ocd_backend/exceptions.py
+++ b/ocd_backend/exceptions.py
@@ -16,6 +16,16 @@ class NoDeserializerAvailable(Exception):
     content-type of an."""
 
 
+class NoChainIDAvailable(Exception):
+    """Thrown when an OCD task tries to clean up it's chain id, and it is not
+    available"""
+
+
+class NoRunIDAvailable(Exception):
+    """Thrown when an OCD task tries to clean up it's chain id, and the run
+    identifier is not available"""
+
+
 class FieldNotAvailable(Exception):
     """Exception thrown when a field could not be found."""
     def __init__(self, field):

--- a/ocd_backend/exceptions.py
+++ b/ocd_backend/exceptions.py
@@ -16,16 +16,6 @@ class NoDeserializerAvailable(Exception):
     content-type of an."""
 
 
-class NoChainIDAvailable(Exception):
-    """Thrown when an OCD task tries to clean up it's chain id, and it is not
-    available"""
-
-
-class NoRunIDAvailable(Exception):
-    """Thrown when an OCD task tries to clean up it's chain id, and the run
-    identifier is not available"""
-
-
 class FieldNotAvailable(Exception):
     """Exception thrown when a field could not be found."""
     def __init__(self, field):

--- a/ocd_backend/loaders/__init__.py
+++ b/ocd_backend/loaders/__init__.py
@@ -8,13 +8,39 @@ from ocd_backend.es import elasticsearch
 from ocd_backend.exceptions import ConfigurationError
 from ocd_backend.log import get_source_logger
 from ocd_backend.mixins import OCDBackendTaskMixin
+from ocd_backend.tasks import UpdateAlias
 
 log = get_source_logger('loader')
+
 
 class BaseLoader(OCDBackendTaskMixin, Task):
     """The base class that other loaders should inherit."""
 
-    ignore_result = False
+    def after_return(self, status, retval, task_id, args, kwargs, einfo):
+        """Remove the chain_id from the set of IDs available for this run.
+        After that, if no more chains are running, or no more tasks are in the
+        process of being added, remove the ID of this run, and call a hook that
+        should be implemented in the actual loader"""
+
+        run_identifier = kwargs.get('run_identifier')
+        run_identifier_chains = '{}_chains'.format(run_identifier)
+        self._remove_chain(run_identifier_chains, kwargs.get('chain_id'))
+
+        if self.backend.get_set_cardinality(run_identifier_chains) < 1 and not self.backend.get(run_identifier):
+            self.backend.remove(run_identifier_chains)
+            self.run_finished(run_identifier_chains)
+
+        # Call any superclass after_return implementation, in order to stay
+        # compatible with chord implementations:
+        # http://docs.celeryproject.org/en/latest/userguide/canvas.html#chords
+        super(OCDBackendTaskMixin, self).after_return(status, retval, task_id,
+                                                      args, kwargs, einfo)
+
+
+    def run_finished(self, run_identifier):
+        raise NotImplementedError('You should define a method that is called '
+                                  'when a run is finished')
+
 
     def run(self, *args, **kwargs):
         """Start loading of a single item.
@@ -55,13 +81,27 @@ class ElasticsearchLoader(BaseLoader):
     ``RESOLVER_URL_INDEX`` (if it doesn't already exist).
     """
     def run(self, *args, **kwargs):
-        print kwargs
-        self.index_name = kwargs.get('index_name')
+        self.current_index_name = kwargs.get('current_index_name')
+        self.index_name = kwargs.get('new_index_name')
+        self.alias = kwargs.get('index_alias')
 
         if not self.index_name:
             raise ConfigurationError('The name of the index is not provided')
 
         return super(ElasticsearchLoader, self).run(*args, **kwargs)
+
+    def after_return(self, status, retval, task_id, args, kwargs, einfo):
+        super(ElasticsearchLoader, self).after_return(status, retval, task_id,
+                                                      args, kwargs, einfo)
+
+
+    def run_finished(self, run_identifier):
+        log.info('Finished run {}. Updating alias "{}" to "{}"'
+                 .format(run_identifier, self.alias, self.index_name))
+        update_alias = UpdateAlias()
+        update_alias.delay(current_index_name=self.current_index_name,
+                           new_index_name=self.index_name,
+                           alias=self.alias)
 
     def load_item(self, object_id, combined_index_doc, doc):
         log.info('Indexing documents...')
@@ -88,11 +128,6 @@ class ElasticsearchLoader(BaseLoader):
                 except ConflictError:
                     log.debug('Resolver document %s already exists' % url_hash)
 
-        return {
-            'item_id': object_id,
-            'task_id': self.request.id,
-        }
-
 
 class DummyLoader(BaseLoader):
     """
@@ -106,3 +141,10 @@ class DummyLoader(BaseLoader):
         print '%s %s %s' % ('-' * 20, 'doc', '-' * 25)
         print doc
         print '=' * 50
+
+    def run_finished(self, run_identifier):
+        print '*' * 50
+        print
+        print 'Finished run {}'.format(run_identifier)
+        print
+        print '*' * 50

--- a/ocd_backend/mixins.py
+++ b/ocd_backend/mixins.py
@@ -1,6 +1,3 @@
-from ocd_backend.exceptions import NoChainIDAvailable
-
-
 class OCDBackendTaskMixin(object):
     """
     Mixin for `Tasks` using the backend, which makes sure the Task cleans up

--- a/ocd_backend/mixins.py
+++ b/ocd_backend/mixins.py
@@ -1,0 +1,19 @@
+from ocd_backend import celery_app
+from ocd_backend.exceptions import NoChainIDAvailable
+
+
+class OCDBackendTaskMixin(object):
+    """
+    Mixin for `Tasks` using the backend, which makes sure the Task cleans up
+    bookkeeping that is happening in the result backend to know when all tasks
+    have finished.
+    """
+    def on_failure(self, exc, task_id, args, kwargs, einfo):
+        if not kwargs.get('chain_id'):
+            raise NoChainIDAvailable
+
+        if not kwargs.get('run_identifier'):
+            raise NoRunIDAvailable
+
+        celery_app.backend.remove_value_from_set('{}_chains'.format(kwargs.get('run_identifier')), kwargs.get('chain_id'))
+        self.AsyncResult(task_id=task_id).forget()

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -56,14 +56,13 @@ def setup_pipeline(source_definition):
     run_identifier_chains = '{}_chains'.format(params['run_identifier'])
 
     try:
-        for i, item in enumerate(extractor.run()):
+        for item in extractor.run():
             # Generate an identifier for each chain, and record that in
             # {}_chains, so that we can know for sure when all tasks from an
             # extractor have finished
             params['chain_id']= uuid4().hex
             celery_app.backend.add_value_to_set(set_name=run_identifier_chains,
                                                 value=params['chain_id'])
-
             (transformer.s(*item, source_definition=source_definition, **params)
              | loader.s(source_definition=source_definition, **params)).delay()
     except:

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -17,7 +17,8 @@ def setup_pipeline(source_definition):
     # index_name is an alias of the current version of the index
     index_alias = '{prefix}_{index_name}'.format(
         prefix=settings.DEFAULT_INDEX_PREFIX,
-        index_name=source_definition.get('index_name')
+        index_name=source_definition.get('index_name',
+                                         source_definition.get('id'))
     )
 
     if not es.indices.exists(index_alias):

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -60,8 +60,6 @@ def setup_pipeline(source_definition):
         celery_app.backend.add_value_to_set(set_name=run_identifier_chains, value=params['chain_id'])
 
         (transformer.s(*item, source_definition=source_definition, **params) | loader.s(source_definition=source_definition, **params)).delay()
-        if i + 1 == 15:
-            break
 
     celery_app.backend.delete(params['run_identifier'])
 

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -72,7 +72,7 @@ def setup_pipeline(source_definition):
                      .format(index=new_index_name,
                              run_identifier=params['run_identifier'],
                              extractor=source_definition['extractor']))
-        
+
         celery_app.backend.set(params['run_identifier'], 'error')
         raise
 

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -72,7 +72,7 @@ def setup_pipeline(source_definition):
                      .format(index=new_index_name,
                              run_identifier=params['run_identifier'],
                              extractor=source_definition['extractor']))
-        es.indices.delete(new_index_name)
+        
         celery_app.backend.set(params['run_identifier'], 'error')
         raise
 

--- a/ocd_backend/pipeline.py
+++ b/ocd_backend/pipeline.py
@@ -7,7 +7,7 @@ from ocd_backend.es import elasticsearch as es
 from ocd_backend import settings, celery_app
 from ocd_backend.tasks import UpdateAlias
 from ocd_backend.utils.misc import load_object
-from .exceptions import ConfigurationError
+from ocd_backend.exceptions import ConfigurationError
 
 
 def setup_pipeline(source_definition):
@@ -41,26 +41,34 @@ def setup_pipeline(source_definition):
     transformer = load_object(source_definition['transformer'])()
     loader = load_object(source_definition['loader'])()
 
-    # update_alias = UpdateAlias()
-
     # Parameters that are passed to each task in the chain
     params = {
         'run_identifier': 'pipeline_{}'.format(uuid4().hex),
         'current_index_name': current_index_name,
-        'index_name': new_index_name
+        'new_index_name': new_index_name,
+        'index_alias': index_alias
     }
+
     celery_app.backend.set(params['run_identifier'], 1)
+    run_identifier_chains = '{}_chains'.format(params['run_identifier'])
 
     for i, item in enumerate(extractor.run()):
         # Generate an identifier for each chain, and record that in {}_chains,
         # so that we can know for sure when all tasks from an extractor have
         # finished
         params['chain_id']= uuid4().hex
-        celery_app.backend.add_value_to_set(set_name='{}_chains'.format(params['run_identifier']), value=params['chain_id'])
+        celery_app.backend.add_value_to_set(set_name=run_identifier_chains, value=params['chain_id'])
 
         (transformer.s(*item, source_definition=source_definition, **params) | loader.s(source_definition=source_definition, **params)).delay()
-        break
+        if i + 1 == 15:
+            break
 
-    # chord(group(tasks))(update_alias.s(current_index_name=current_index_name,
-    #                                    new_index_name=new_index_name,
-    #                                    alias=index_alias))
+    celery_app.backend.delete(params['run_identifier'])
+
+    # If the last chain finishes BEFORE the run_identifier could be deleted
+    # (this happened during development), fire the update_alias
+    if celery_app.backend.get_set_cardinality(run_identifier_chains) < 1:
+        celery_app.backend.remove(run_identifier_chains)
+        update_alias = UpdateAlias()
+        update_alias.delay(current_index_name=current_index_name,
+                           new_index_name=new_index_name, alias=index_alias)

--- a/ocd_backend/result_backends.py
+++ b/ocd_backend/result_backends.py
@@ -30,6 +30,10 @@ class OCDBackendMixin(object):
         """Set `key` to `value`"""
         raise NotImplementedError('Subclass should implement `get` method')
 
+    def remove(self, key):
+        """Remove `key`"""
+        raise NotImplementedError('Subclass should implement `remove` method')
+
     def add_value_to_set(self, set_name, value):
         """Add `value` to `set_name`"""
         raise NotImplementedError('Subclass should implement `add_to_set` '
@@ -52,10 +56,13 @@ class OCDRedisBackend(RedisBackend, OCDBackendMixin):
         self.client.sadd(set_name, value)
 
     def remove_value_from_set(self, set_name, value):
-        self.client.srem(set_name. value)
+        self.client.srem(set_name, value)
 
     def get_set_cardinality(self, set_name):
         return self.client.scard(set_name)
 
     def get_set_members(self, set_name):
         return self.client.smembers(set_name)
+
+    def remove(self, key):
+        return self.client.delete(key)

--- a/ocd_backend/result_backends.py
+++ b/ocd_backend/result_backends.py
@@ -1,0 +1,61 @@
+from celery.backends.redis import RedisBackend
+
+
+class OCDBackendMixin(object):
+    """
+    This mixin defines the methods that we expect the result backend to
+    implement. We use this to make sure the backend that is used supports the
+    functionality that we require for the ETL pipeline.
+
+    You should subclass one of Celery's backend classes, and add this mixin
+    **after** the class definition. For example:
+
+        from celery.backends.cassandra import CassandraBackend
+
+        class MyOCDBackend(CassandraBackend, OCDBackendMixin):
+
+            implements_incr = True
+
+            def incr(self, key):
+                # implementation of incr on Cassandra backend
+
+    This will make sure whether the subclass has implemented all the required
+    methods, and allow it to override specific methods if required.
+    """
+    def get(self, key):
+        """Get value by `key`"""
+        raise NotImplementedError('Subclass should implement `get` method')
+
+    def set(self, key, value):
+        """Set `key` to `value`"""
+        raise NotImplementedError('Subclass should implement `get` method')
+
+    def add_value_to_set(self, set_name, value):
+        """Add `value` to `set_name`"""
+        raise NotImplementedError('Subclass should implement `add_to_set` '
+                                  'method')
+
+    def remove_value_from_set(self, set_name, value):
+        """Remove `value` from `set_name`"""
+        raise NotImplementedError('Subclass should implement `remove_value_fro'
+                                  'm_set` method')
+
+    def get_set_cardinality(self, set_name):
+        """Get the number of values stored in `set_name`"""
+        raise NotImplementedError('Subclass should implement `get_set_cardinal'
+                                  'ity` method')
+
+
+class OCDRedisBackend(RedisBackend, OCDBackendMixin):
+
+    def add_value_to_set(self, set_name, value):
+        self.client.sadd(set_name, value)
+
+    def remove_value_from_set(self, set_name, value):
+        self.client.srem(set_name. value)
+
+    def get_set_cardinality(self, set_name):
+        return self.client.scard(set_name)
+
+    def get_set_members(self, set_name):
+        return self.client.smembers(set_name)

--- a/ocd_backend/result_backends.py
+++ b/ocd_backend/result_backends.py
@@ -49,6 +49,9 @@ class OCDBackendMixin(object):
         raise NotImplementedError('Subclass should implement `get_set_cardinal'
                                   'ity` method')
 
+    def update_ttl(self, key, ttl=300):
+        """Extend the TTL of `key` with `ttl` seconds"""
+
 
 class OCDRedisBackend(RedisBackend, OCDBackendMixin):
 
@@ -66,3 +69,6 @@ class OCDRedisBackend(RedisBackend, OCDBackendMixin):
 
     def remove(self, key):
         return self.client.delete(key)
+
+    def update_ttl(self, key, ttl=300):
+        return self.client.expire(key, ttl)

--- a/ocd_backend/settings.py
+++ b/ocd_backend/settings.py
@@ -13,7 +13,7 @@ CELERY_CONFIG = {
     'CELERY_ACCEPT_CONTENT': ['ocd_serializer'],
     'CELERY_TASK_SERIALIZER': 'ocd_serializer',
     'CELERY_RESULT_SERIALIZER': 'ocd_serializer',
-    'CELERY_RESULT_BACKEND': 'redis://127.0.0.1:6379/0',
+    'CELERY_RESULT_BACKEND': 'ocd_backend.result_backends:OCDRedisBackend+redis://127.0.0.1:6379/0',
     'CELERY_IGNORE_RESULT': True,
     'CELERY_DISABLE_RATE_LIMITS': True,
     # Expire results after 30 minutes; otherwise Redis will keep claiming memory

--- a/ocd_backend/sources.json
+++ b/ocd_backend/sources.json
@@ -5,7 +5,8 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.rijksmuseum.RijksmuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
-        "rijksmuseum_api_key": ""
+        "rijksmuseum_api_key": "",
+        "index_name": "rijksmuseum"
     },
     {
         "id": "openbeelden",
@@ -14,7 +15,8 @@
         "item": "ocd_backend.items.openbeelden.OpenbeeldenItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "oai_base_url": "http://www.openbeelden.nl/feeds/oai/",
-        "oai_metadata_prefix": "oai_oi"
+        "oai_metadata_prefix": "oai_oi",
+        "index_name": "open-beelden"
     },
     {
         "id": "amsterdammuseum",
@@ -23,7 +25,8 @@
         "item": "ocd_backend.items.amsterdammuseum.AmsterdamMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "oai_base_url": "http://ahm.adlibsoft.com/oaix/oai.ashx",
-        "oai_metadata_prefix": "oai_dc"
+        "oai_metadata_prefix": "oai_dc",
+        "index_name": "amsterdam-museum"
     },
     {
         "id": "nationaal_archief_beeldbank",
@@ -32,7 +35,8 @@
         "item": "ocd_backend.items.nabeeldbank.NationaalArchiefBeeldbankItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "opensearch_url": "http://www.gahetna.nl/beeldbank-api/opensearch/",
-        "opensearch_query": "\"*:*\""
+        "opensearch_query": "\"*:*\"",
+        "index_name": "nationaal-archief-beeldbank"
     },
     {
         "id": "centraal_museum_utrecht",
@@ -41,7 +45,8 @@
         "item": "ocd_backend.items.cmutrecht.CentraalMuseumUtrechtItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "file_url": "http://static.opencultuurdata.nl/centraal_museum_utrecht/cmu.xml",
-        "item_xpath": "//record"
+        "item_xpath": "//record",
+        "index_name": "centraal-museum-utrecht"
     },
     {
         "id": "openarchieven",
@@ -50,7 +55,8 @@
         "item": "ocd_backend.items.openarchieven.OpenArchievenItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "oai_base_url": "http://api.openarch.nl/oai-pmh/",
-        "oai_metadata_prefix": "oai_a2a"
+        "oai_metadata_prefix": "oai_a2a",
+        "index_name": "open-archieven"
     },
     {
         "id": "erfgoed_leiden_beeldbank",
@@ -59,7 +65,8 @@
         "item": "ocd_backend.items.elobeeldbank.ErfgoedLeidenBeeldbankItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "opensearch_url": "http://www.archiefleiden.nl/api/opensearch/",
-        "opensearch_query": "\"*:*\""
+        "opensearch_query": "\"*:*\"",
+        "index_name": "beeldbank-erfgoed-leiden"
     },
     {
         "id": "kb_byvanckb",
@@ -69,7 +76,8 @@
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "oai_base_url": "http://services.kb.nl/mdo/oai",
         "oai_metadata_prefix": "dcx",
-        "oai_set": "ByvanckB"
+        "oai_set": "ByvanckB",
+        "index_name": "byvanckb-koninklijke-bibliotheek"
     },
     {
         "id": "uukaarten",
@@ -79,7 +87,8 @@
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "oai_base_url": "http://dspace.library.uu.nl/oai/request",
         "oai_metadata_prefix": "oai_dc",
-        "oai_set": "col_1874_213366"
+        "oai_set": "col_1874_213366",
+        "index_name": "kaarten-universiteitsbibliotheek-utrecht"
     },
     {
         "id": "zoutkamp",
@@ -89,7 +98,8 @@
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "adlib_base_url": "http://mmr.adlibhosting.com/madigopacx/wwwopac.ashx",
         "adlib_database": "ChoiceMardig",
-        "adlib_query": "museum=0011"
+        "adlib_query": "museum=0011",
+        "index_name": "visserijmuseum-zoutkamp"
     },
     {
         "id": "textielmuseum",
@@ -98,7 +108,8 @@
         "item": "ocd_backend.items.textielmuseum.TextielMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "adlib_base_url": "http://37.17.215.121:85/opendata/wwwopac.ashx",
-        "adlib_database": "collect"
+        "adlib_database": "collect",
+        "index_name": "textielmuseum"
     },
     {
         "id": "tropenmuseum",
@@ -107,7 +118,8 @@
         "item": "ocd_backend.items.tropenmuseum.TropenMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "wikimedia_base_url": "http://commons.wikimedia.org/w/api.php",
-        "wikimedia_category": "Category:Images_from_the_Tropenmuseum"
+        "wikimedia_category": "Category:Images_from_the_Tropenmuseum",
+        "index_name": "tropenmuseum",
     },
     {
         "id": "fries_museum",
@@ -116,7 +128,8 @@
         "item": "ocd_backend.items.friesmuseum.FriesMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
         "file_url": "http://static.opencultuurdata.nl/fries_museum/20120616_Textiel_Hack_FM.xml",
-        "item_xpath": "//adlibXML/recordList/record"
+        "item_xpath": "//adlibXML/recordList/record",
+        "index_name": "mode-fries-museum"
     },
     {
         "id": "museum_rotterdam",
@@ -145,23 +158,26 @@
             "associatie":23,
             "herkomst":40,
             "licentie":85
-        }
+        },
+        "index_name": "museum-rotterdam"
     },
     {
-      "id": "ra_tilburg",
-      "extractor": "ocd_backend.extractors.oai.OaiExtractor",
-      "transformer": "ocd_backend.transformers.BaseTransformer",
-      "item": "ocd_backend.items.ra_tilburg.RegionaalArchiefTilburgItem",
-      "loader": "ocd_backend.loaders.ElasticsearchLoader",
-      "oai_base_url": "http://api.memorix-maior.nl/collectiebeheer/a2a/key/42de466c-8cb5-11e3-9b8b-00155d012a18/tenant/tlb",
-      "oai_metadata_prefix": "oai_a2a"
+        "id": "ra_tilburg",
+        "extractor": "ocd_backend.extractors.oai.OaiExtractor",
+        "transformer": "ocd_backend.transformers.BaseTransformer",
+        "item": "ocd_backend.items.ra_tilburg.RegionaalArchiefTilburgItem",
+        "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "oai_base_url": "http://api.memorix-maior.nl/collectiebeheer/a2a/key/42de466c-8cb5-11e3-9b8b-00155d012a18/tenant/tlb",
+        "oai_metadata_prefix": "oai_a2a",
+        "index_name": "regionaal-archief-tilburg"
     },
     {
-      "id": "gemeente_ede",
-      "extractor": "ocd_backend.extractors.staticfile.StaticJSONExtractor",
-      "transformer": "ocd_backend.transformers.BaseTransformer",
-      "item": "ocd_backend.items.gemeente_ede.GemeenteEdeItem",
-      "loader": "ocd_backend.loaders.ElasticsearchLoader",
-      "file_url": "http://static.opencultuurdata.nl/gemeente_ede/2014OpenData_ABWigman_CSV_06-12.json"
+        "id": "gemeente_ede",
+        "extractor": "ocd_backend.extractors.staticfile.StaticJSONExtractor",
+        "transformer": "ocd_backend.transformers.BaseTransformer",
+        "item": "ocd_backend.items.gemeente_ede.GemeenteEdeItem",
+        "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "file_url": "http://static.opencultuurdata.nl/gemeente_ede/2014OpenData_ABWigman_CSV_06-12.json",
+        "index_name": "gemeente-ede"
     }
 ]

--- a/ocd_backend/sources.json
+++ b/ocd_backend/sources.json
@@ -5,6 +5,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.rijksmuseum.RijksmuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "rijksmuseum_api_key": "",
         "index_name": "rijksmuseum"
     },
@@ -14,6 +15,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.openbeelden.OpenbeeldenItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "oai_base_url": "http://www.openbeelden.nl/feeds/oai/",
         "oai_metadata_prefix": "oai_oi",
         "index_name": "open-beelden"
@@ -24,6 +26,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.amsterdammuseum.AmsterdamMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "oai_base_url": "http://ahm.adlibsoft.com/oaix/oai.ashx",
         "oai_metadata_prefix": "oai_dc",
         "index_name": "amsterdam-museum"
@@ -34,6 +37,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.nabeeldbank.NationaalArchiefBeeldbankItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "opensearch_url": "http://www.gahetna.nl/beeldbank-api/opensearch/",
         "opensearch_query": "\"*:*\"",
         "index_name": "nationaal-archief-beeldbank"
@@ -44,6 +48,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.cmutrecht.CentraalMuseumUtrechtItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "file_url": "http://static.opencultuurdata.nl/centraal_museum_utrecht/cmu.xml",
         "item_xpath": "//record",
         "index_name": "centraal-museum-utrecht"
@@ -54,6 +59,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.openarchieven.OpenArchievenItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "oai_base_url": "http://api.openarch.nl/oai-pmh/",
         "oai_metadata_prefix": "oai_a2a",
         "index_name": "open-archieven"
@@ -64,6 +70,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.elobeeldbank.ErfgoedLeidenBeeldbankItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "opensearch_url": "http://www.archiefleiden.nl/api/opensearch/",
         "opensearch_query": "\"*:*\"",
         "index_name": "beeldbank-erfgoed-leiden"
@@ -74,6 +81,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.byvanckb.ByvanckBItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "oai_base_url": "http://services.kb.nl/mdo/oai",
         "oai_metadata_prefix": "dcx",
         "oai_set": "ByvanckB",
@@ -85,6 +93,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.uukaarten.UUKaartenItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "oai_base_url": "http://dspace.library.uu.nl/oai/request",
         "oai_metadata_prefix": "oai_dc",
         "oai_set": "col_1874_213366",
@@ -96,6 +105,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.zoutkamp.ZoutkampItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "adlib_base_url": "http://mmr.adlibhosting.com/madigopacx/wwwopac.ashx",
         "adlib_database": "ChoiceMardig",
         "adlib_query": "museum=0011",
@@ -107,6 +117,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.textielmuseum.TextielMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "adlib_base_url": "http://37.17.215.121:85/opendata/wwwopac.ashx",
         "adlib_database": "collect",
         "index_name": "textielmuseum"
@@ -117,6 +128,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.tropenmuseum.TropenMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "wikimedia_base_url": "http://commons.wikimedia.org/w/api.php",
         "wikimedia_category": "Category:Images_from_the_Tropenmuseum",
         "index_name": "tropenmuseum",
@@ -127,6 +139,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.friesmuseum.FriesMuseumItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "file_url": "http://static.opencultuurdata.nl/fries_museum/20120616_Textiel_Hack_FM.xml",
         "item_xpath": "//adlibXML/recordList/record",
         "index_name": "mode-fries-museum"
@@ -137,6 +150,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.museum_rotterdam.MuseumRotterdamItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "file_url": "http://static.opencultuurdata.nl/museum_rotterdam/MuseumRotterdamCollectie19082014.xml",
         "item_xpath": "//cb3:record",
         "default_namespace": "cb3",
@@ -167,6 +181,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.ra_tilburg.RegionaalArchiefTilburgItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "oai_base_url": "http://api.memorix-maior.nl/collectiebeheer/a2a/key/42de466c-8cb5-11e3-9b8b-00155d012a18/tenant/tlb",
         "oai_metadata_prefix": "oai_a2a",
         "index_name": "regionaal-archief-tilburg"
@@ -177,6 +192,7 @@
         "transformer": "ocd_backend.transformers.BaseTransformer",
         "item": "ocd_backend.items.gemeente_ede.GemeenteEdeItem",
         "loader": "ocd_backend.loaders.ElasticsearchLoader",
+        "cleanup": "ocd_backend.tasks.CleanupElasticsearch",
         "file_url": "http://static.opencultuurdata.nl/gemeente_ede/2014OpenData_ABWigman_CSV_06-12.json",
         "index_name": "gemeente-ede"
     }

--- a/ocd_backend/tasks.py
+++ b/ocd_backend/tasks.py
@@ -15,19 +15,6 @@ class UpdateAlias(Task):
         new_index_name = kwargs.get('new_index_name')
         alias = kwargs.get('alias')
 
-        # Results are stored up to 30 minutes by default in the Redis storage
-        # backend, but we'll clean up here to limit strain on resources
-        for r in args[0]:
-            log.debug('Processed item {item_id}; removing tasks ({task_id}, '
-                      '{transformer_task_id}) from result backend'
-                      .format(item_id=r.get('item_id'),
-                              task_id=r.get('task_id'),
-                              transformer_task_id=r.get('transformer_task_id')
-                )
-            )
-            self.AsyncResult(task_id=r.get('task_id')).forget()
-            self.AsyncResult(task_id=r.get('transformer_task_id')).forget()
-
         actions = {
             'actions': [
                 {'remove': {'index': current_index_name, 'alias': alias}},

--- a/ocd_backend/tasks.py
+++ b/ocd_backend/tasks.py
@@ -26,4 +26,5 @@ class UpdateAlias(Task):
         es.indices.update_aliases(body=actions)
 
         # Remove old index
-        es.indices.delete(index=current_index_name)
+        if current_index_name != new_index_name:
+            es.indices.delete(index=current_index_name)

--- a/ocd_backend/tasks.py
+++ b/ocd_backend/tasks.py
@@ -1,5 +1,6 @@
 from celery import Task
 
+from ocd_backend import settings
 from ocd_backend.es import elasticsearch as es
 from ocd_backend.log import get_source_logger
 
@@ -7,18 +8,57 @@ from ocd_backend.log import get_source_logger
 log = get_source_logger('ocd_backend.tasks')
 
 
-class UpdateAlias(Task):
+class BaseCleanup(Task):
     ignore_result = True
 
     def run(self, *args, **kwargs):
+        run_identifier = kwargs.get('run_identifier')
+        run_identifier_chains = '{}_chains'.format(run_identifier)
+        self._remove_chain(run_identifier_chains, kwargs.get('chain_id'))
+
+        if self.backend.get_set_cardinality(run_identifier_chains) < 1 and self.backend.get(run_identifier) == 'done':
+            self.backend.remove(run_identifier_chains)
+            self.run_finished(**kwargs)
+        else:
+            # If the extractor is still running, extend the lifetime of the
+            # identifier
+            self.backend.update_ttl(run_identifier, settings.CELERY_CONFIG
+                                    .get('CELERY_TASK_RESULT_EXPIRES', 1800))
+
+    def _remove_chain(self, run_identifier, value):
+        self.backend.remove_value_from_set(run_identifier, value)
+
+    def run_finished(self, run_identifier, **kwargs):
+        raise NotImplementedError('Cleanup is highly dependent on what you use '
+                                  'for storage, so this should be implemented '
+                                  'in a subclass.')
+
+
+class CleanupElasticsearch(BaseCleanup):
+
+    def run_finished(self, run_identifier, **kwargs):
         current_index_name = kwargs.get('current_index_name')
         new_index_name = kwargs.get('new_index_name')
-        alias = kwargs.get('alias')
+        alias = kwargs.get('index_alias')
+
+        log.info('Finished run {}. Removing alias "{}" from "{}", and applying'
+                 'it to "{}"'.format(run_identifier, alias, current_index_name,
+                                     new_index_name))
 
         actions = {
             'actions': [
-                {'remove': {'index': current_index_name, 'alias': alias}},
-                {'add': {'index': new_index_name, 'alias': alias}}
+                {
+                    'remove': {
+                        'index': current_index_name,
+                        'alias': alias
+                    }
+                },
+                {
+                    'add': {
+                        'index': new_index_name,
+                        'alias': alias
+                    }
+                }
             ]
         }
 

--- a/ocd_backend/transformers/__init__.py
+++ b/ocd_backend/transformers/__init__.py
@@ -6,10 +6,11 @@ from celery import Task
 
 from ocd_backend import settings
 from ocd_backend.exceptions import NoDeserializerAvailable
+from ocd_backend.mixins import OCDBackendTaskMixin
 from ocd_backend.utils.misc import load_object
 
 
-class BaseTransformer(Task):
+class BaseTransformer(OCDBackendTaskMixin, Task):
 
     ignore_result = False
 
@@ -76,4 +77,4 @@ class BaseTransformer(Task):
 
         self.add_resolveable_media_urls(item)
 
-        return item.get_object_id(), item.get_combined_index_doc(), item.get_index_doc(), self.request.id
+        return item.get_object_id(), item.get_combined_index_doc(), item.get_index_doc()

--- a/ocd_backend/transformers/__init__.py
+++ b/ocd_backend/transformers/__init__.py
@@ -12,8 +12,6 @@ from ocd_backend.utils.misc import load_object
 
 class BaseTransformer(OCDBackendTaskFailureMixin, Task):
 
-    ignore_result = False
-
     def run(self, *args, **kwargs):
         """Start transformation of a single item.
 

--- a/ocd_backend/transformers/__init__.py
+++ b/ocd_backend/transformers/__init__.py
@@ -6,11 +6,11 @@ from celery import Task
 
 from ocd_backend import settings
 from ocd_backend.exceptions import NoDeserializerAvailable
-from ocd_backend.mixins import OCDBackendTaskMixin
+from ocd_backend.mixins import OCDBackendTaskFailureMixin
 from ocd_backend.utils.misc import load_object
 
 
-class BaseTransformer(OCDBackendTaskMixin, Task):
+class BaseTransformer(OCDBackendTaskFailureMixin, Task):
 
     ignore_result = False
 

--- a/ocd_frontend/settings.py
+++ b/ocd_frontend/settings.py
@@ -22,7 +22,7 @@ SORTABLE_FIELDS = (
     'date', 'date_granularity', 'authors', '_score'
 )
 
-# Defenition of the ES facets (and filters) that are accassible through
+# Definition of the ES facets (and filters) that are accessible through
 # the REST API
 AVAILABLE_FACETS = {
     # 'retrieved_at': {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-celery[redis]==3.1.10
-elasticsearch==1.2.0
+celery[redis]==3.1.17
+elasticsearch==1.3.0
 click==2.1
 coverage==4.0a1
 Flask==0.10.1

--- a/tests/ocd_backend/transformers/base.py
+++ b/tests/ocd_backend/transformers/base.py
@@ -37,8 +37,7 @@ class BaseTransformerTestCase(TransformerTestCase):
     def test_run(self):
         # This implicitly tests item functionality too. Perhaps we want to mock
         # this?
-        object_id, combi_doc, doc, task_id = self.transformer.run(*self.item, source_definition=self.source_definition)
+        object_id, combi_doc, doc = self.transformer.run(*self.item, source_definition=self.source_definition)
         self.assertIsNotNone(object_id)
         self.assertIsNotNone(combi_doc)
         self.assertIsNotNone(doc)
-        self.assertIsNone(task_id)


### PR DESCRIPTION
With the introduction of the collection refresh mechanism (see #77) a Celery chord construct was created in the pipeline, in order to determine when a pipeline has finished so the Elasticsearch aliases could be transferred to the newly created index.

However, this requires Redis to first create all parallel tasks and keep them in memory before the chord callback method updating the index alias could be called. That means that an extractor has to finish its run before any tasks could start being executed. This is undesirable, since for many collections (such as Rijksmuseum) it can take a long time to generate all tasks, and even worse, do not fit into memory.

This pull request provides a solution that generates a unique ID for each pipeline that is created, and stores that in the Celery result backend (currently we use Redis, but the implementation in `ocd_backend/result_backends.py` provides a simple interface to extend to other backends as well). Then, it creates an ID for each chain/item that is to be processed, and stores those in a set in the backend as well.

`ocd_backend/result_backends.py` provides a mixin for tasks that can remove the identifier of that chain from that set when an error occurs. The loaders in `ocd_backend/loaders/__init__.py` provide an additional hook that checks if there are any tasks currently left running (i.e. there are still values in the set), or if the extractor is still generating tasks.

**N.B.:** some additional unit tests are in the works, but this issue is blocking work on other components. @justinvw please review the changes carefully :-)